### PR TITLE
Use crypto if available

### DIFF
--- a/raftos/conf.py
+++ b/raftos/conf.py
@@ -21,7 +21,6 @@ class Configuration:
             'election_interval_spread': 3,
 
             # For UDP messages encryption
-            'use_protocol_encryption': False,
             'secret_key': b'raftos sample secret key',
             'salt': b'raftos sample salt',
 
@@ -39,9 +38,6 @@ class Configuration:
             self.step_down_interval,
             self.step_down_interval * self.election_interval_spread
         )
-        if self.use_protocol_encryption:
-            from . cryptor import enable_encryption
-            enable_encryption()
 
 
 config = Configuration()

--- a/raftos/conf.py
+++ b/raftos/conf.py
@@ -1,6 +1,5 @@
 from .serializers import MessagePackSerializer
 
-
 class Configuration:
     def __init__(self):
         self.configure(self.default_settings())
@@ -22,6 +21,7 @@ class Configuration:
             'election_interval_spread': 3,
 
             # For UDP messages encryption
+            'use_protocol_encryption': False,
             'secret_key': b'raftos sample secret key',
             'salt': b'raftos sample salt',
 
@@ -39,6 +39,9 @@ class Configuration:
             self.step_down_interval,
             self.step_down_interval * self.election_interval_spread
         )
+        if self.use_protocol_encryption:
+            from . cryptor import enable_encryption
+            enable_encryption()
 
 
 config = Configuration()

--- a/raftos/cryptor.py
+++ b/raftos/cryptor.py
@@ -1,29 +1,37 @@
-import base64
-
-from cryptography.fernet import Fernet
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
 from .conf import config
 
-
-class Cryptor:
-    def __init__(self):
-        kdf = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=32,
-            salt=config.salt,
-            iterations=100000,
-            backend=default_backend()
-        )
-        self.f = Fernet(base64.urlsafe_b64encode(kdf.derive(config.secret_key)))
-
+class DummyCryptor:
     def encrypt(self, data):
-        return self.f.encrypt(data)
+        return data
 
     def decrypt(self, data):
-        return self.f.decrypt(data)
+        return data
 
+def enable_encryption():
+    import base64
+    from cryptography.fernet import Fernet
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    #
+    class Cryptor:
+        def __init__(self):
+            kdf = PBKDF2HMAC(
+                algorithm=hashes.SHA256(),
+                length=32,
+                salt=config.salt,
+                iterations=100000,
+                backend=default_backend()
+            )
+            self.f = Fernet(base64.urlsafe_b64encode(kdf.derive(config.secret_key)))
 
-cryptor = Cryptor()
+        def encrypt(self, data):
+            return self.f.encrypt(data)
+
+        def decrypt(self, data):
+            return self.f.decrypt(data)
+    #
+    global cryptor
+    cryptor = Cryptor()
+
+cryptor = DummyCryptor()

--- a/raftos/cryptor.py
+++ b/raftos/cryptor.py
@@ -1,5 +1,16 @@
 from .conf import config
 
+try:
+    import base64
+    from cryptography.fernet import Fernet
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    crypt_available = True
+except ImportError:
+    crypt_available = False
+
+#
 class DummyCryptor:
     def encrypt(self, data):
         return data
@@ -7,13 +18,7 @@ class DummyCryptor:
     def decrypt(self, data):
         return data
 
-def enable_encryption():
-    import base64
-    from cryptography.fernet import Fernet
-    from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-    #
+if crypt_available:
     class Cryptor:
         def __init__(self):
             kdf = PBKDF2HMAC(
@@ -31,7 +36,6 @@ def enable_encryption():
         def decrypt(self, data):
             return self.f.decrypt(data)
     #
-    global cryptor
     cryptor = Cryptor()
-
-cryptor = DummyCryptor()
+else:
+    cryptor = DummyCryptor()

--- a/requirements-cryptography.txt
+++ b/requirements-cryptography.txt
@@ -1,0 +1,1 @@
+cryptography==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-cryptography==1.5.3
 msgpack-python==0.4.8

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ __version__ = '0.2.3'
 
 short_description = 'Raft replication in Python'
 requirements = [req.strip() for req in open('requirements.txt').readlines()]
+crypto_reqs = [req.strip() for req in open('requirements-cryptography.txt').readlines()]
 
 setup(
     name='raftos',
@@ -20,6 +21,9 @@ setup(
     url='https://github.com/zhebrak/raftos',
     keywords=['python', 'raft', 'replication'],
     install_requires=requirements,
+    extras_require={
+        'cryptography': crypto_reqs,
+    },
     include_package_data=True,
     classifiers=[],
 )


### PR DESCRIPTION
Hi @zhebrak, I think this is a better pull request.  It maintains the default behavior of previous versions where cryptography is used by default, and it allows someone in pip to use raftos[cryptography] if they want to force cryptography on install.  This also works for my behavior where I can install just raftos without the cryptography and it'll just work.